### PR TITLE
Seal Solidifier for better performance

### DIFF
--- a/Code/Entities/Modifiers/CollidableModifier.cs
+++ b/Code/Entities/Modifiers/CollidableModifier.cs
@@ -70,7 +70,7 @@ namespace Celeste.Mod.EeveeHelper.Entities.Modifiers {
         }
 
 
-        public class Solidifier : Solid {
+        public sealed class Solidifier : Solid {
             public Entity Entity;
 
             public Solidifier(Entity entity) : base(EeveeUtils.GetPosition(entity), 1f, 1f, false) {


### PR DESCRIPTION
Seals the `CollidableModifier.Solidifier` class, which is used in the famous `Collide_Check_Entity_Entity` hook:
```cs
 if (a == null || b == null || (a is CollidableModifier.Solidifier aSolid && aSolid.Entity == b) ||
    (b is CollidableModifier.Solidifier bSolid && bSolid.Entity == a)) {
    return false;
}
```
`is` checks on sealed classes get compiled down to one int comparison, while on non-sealed classes, it requires a much slower operation.

Checked on .NET Core branch of everest, in the last gameplay room of Stellaris:
![image](https://github.com/JaThePlayer/eevee-helper/assets/50085307/46dbdc9e-6a98-4e94-8711-b13855dedd24)
![image](https://github.com/JaThePlayer/eevee-helper/assets/50085307/567cd215-9bc8-48e3-bad9-be7e9f502afd)
